### PR TITLE
Initial Implementation

### DIFF
--- a/lib/branca.rb
+++ b/lib/branca.rb
@@ -1,5 +1,12 @@
 # frozen_string_literal: true
 
+require "securerandom"
+
 module Branca
+  def self.key
+    SecureRandom.random_bytes(32)
+  end
+
+  require_relative "branca/token"
   require_relative "branca/version"
 end

--- a/lib/branca/token.rb
+++ b/lib/branca/token.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "b3bm"
+require "core/global"
+require "openssl"
+require "securerandom"
+
+module Branca
+  class Token
+    include Is::Global
+
+    def initialize(cipher: "chacha20", version: 0xBA, encoder: B3bm.method(:encode), decoder: B3bm.method(:decode))
+      @cipher = cipher
+      @version = version
+      @encoder = encoder
+      @decoder = decoder
+    end
+
+    def encode(payload, key:, timestamp: Time.now)
+      nonce = SecureRandom.random_bytes(24)
+      header = [@version, timestamp.to_i].pack("C N") + nonce
+
+      cipher = OpenSSL::Cipher.new(@cipher)
+      cipher.encrypt
+      cipher.iv = nonce
+      cipher.key = key
+
+      encrypted = cipher.update(payload) + cipher.final
+      encoder.call(encrypted)
+    end
+
+    def decode(payload, key:, ttl: nil)
+    end
+  end
+end

--- a/spec/features/expiration_spec.rb
+++ b/spec/features/expiration_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe "expiring tokens" do
+  it "needs specs"
+end

--- a/spec/features/key_spec.rb
+++ b/spec/features/key_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.describe "generating a key" do
+  it "generates a 32 byte key"
+  it "generates a unique key"
+end

--- a/spec/features/security_spec.rb
+++ b/spec/features/security_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+RSpec.describe "security" do
+  it "does not decode a token with an invalid key"
+  it "does not decode a token that has been tampered with"
+end

--- a/spec/features/token_spec.rb
+++ b/spec/features/token_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "securerandom"
+
+require "branca"
+
+RSpec.describe "tokens" do
+  let(:key) {
+    Branca.key
+  }
+
+  let(:encoded) {
+    Branca::Token.encode(payload, key: key)
+  }
+
+  let(:decoded) {
+    Branca::Token.decode(payload, key: key)
+  }
+
+  context "string payload" do
+    let(:payload) {
+      SecureRandom.alphanumeric(128)
+    }
+
+    it "encodes" do
+      pp encoded
+    end
+
+    it "decodes"
+  end
+
+  context "byte string payload" do
+    it "encodes"
+    it "decodes"
+  end
+end


### PR DESCRIPTION
This will remain in draft until openssl supports `XChaCha20-Poly1305`: https://github.com/openssl/openssl/issues/5523. One of my goals with this library is portability, so falling back to something like `rbnacl` is something I'd like to avoid. If the extra dependency is acceptable to you, consider taking a look at the [`branca-ruby`](https://rubygems.org/gems/branca-ruby) implementation.
